### PR TITLE
add font color support

### DIFF
--- a/src/util/bmfont.rs
+++ b/src/util/bmfont.rs
@@ -73,7 +73,7 @@ fn gen_outline<T: DistanceStorage>(sdf: SignedDistanceField<T>, size: f32) -> im
 }*/
 
 fn generate_char(
-	_font: &BitmapFont,
+	font: &BitmapFont,
 	metrics: fontdue::Metrics,
 	data: Vec<u8>,
 ) -> Option<RgbaImage> {
@@ -104,7 +104,7 @@ fn generate_char(
 	let height = metrics.height as u32;
 
 	Some(RgbaImage::from_fn(width, height, |x, y| {
-		Rgba::<u8>([255, 255, 255, data[(x + width * y) as usize]])
+		Rgba::<u8>([font.color[0], font.color[1], font.color[2], data[(x + width * y) as usize]])
 	}))
 }
 

--- a/src/util/mod_file.rs
+++ b/src/util/mod_file.rs
@@ -12,6 +12,7 @@ pub struct BitmapFont {
 	pub charset: Option<String>,
 	pub size: u32,
 	pub outline: u32,
+	pub color: [u8; 3],
 }
 
 pub struct ModResources {
@@ -145,6 +146,7 @@ fn get_mod_resources(root: &Value, root_path: &Path) -> ModResources {
 							charset: None,
 							size: 0,
 							outline: 0,
+							color: [255, 255, 255],
 						};
 
 						// Iterate font attributes
@@ -176,6 +178,23 @@ fn get_mod_resources(root: &Value, root_path: &Path) -> ModResources {
 										"{}.outline: Expected unsigned integer",
 										info_name
 									)) as u32;
+								}
+
+								"color" => {
+									let color = value
+										.as_str()
+										.nice_unwrap(format!("{}.color: Expected string", info_name));
+
+									let col = u32::from_str_radix(color, 16).nice_unwrap(format!(
+										"{}.color: Expected hexadecimal color",
+										info_name
+									));
+
+									font.color = [
+										((col >> 16) & 0xFF) as u8,
+										((col >> 8) & 0xFF) as u8,
+										(col & 0xFF) as u8,
+									];
 								}
 
 								"charset" => {


### PR DESCRIPTION
This adds support to color fonts when packaging resources by setting the `color` value for a font like so:
```json
"resources": {
		"fonts": {
			"bigFont": {
				"path": "resources/fonts/Quicksand-Bold.ttf",
				"size": 80
			},
			"goldFont": {
				"path": "resources/fonts/Quicksand-Bold.ttf",
				"size": 80,
				"color": "ecd018"
			},
			"chatFont": {
				"path": "resources/fonts/Quicksand-Regular.ttf",
				"size": 56
			}
		}
	}
```

This allows for fonts to have another color than just white which might be useful to some people.

![image](https://user-images.githubusercontent.com/78933889/201205494-20b3d377-3b7c-4c9f-ba8c-c52d8009e9c9.png)
