### PR TITLE
Update CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,9 +695,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.25"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29229cc1b24c0e6062f6e742aa3e256492a5323365e5ed3413599f8a5eff7d6"
+checksum = "8b7905cdfe33d31a88bb2e8419ddd054451f5432d1da9eaf2ac7804ee1ea12d5"
 dependencies = [
  "bitflags",
  "libc",
@@ -1027,9 +1027,9 @@ checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.26+1.3.0"
+version = "0.15.1+1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e1c899248e606fbfe68dcb31d8b0176ebab833b103824af31bddf4b7457494"
+checksum = "fb4577bde8cdfc7d6a2a4bcb7b049598597de33ffd337276e9c7db6cd4a2cee7"
 dependencies = [
  "cc",
  "libc",
@@ -1041,9 +1041,9 @@ dependencies = [
 
 [[package]]
 name = "libssh2-sys"
-version = "0.2.23"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,3 @@ ansi_term = "0.12"
 
 [build-dependencies]
 winres = "0.1.12"
-
-[profile.release]
-lto = true
-codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ clap = { version = "4.1.4", features = ["derive"] }
 colored = "2"
 dirs = "4.0.0"
 fontdue = "0.7.2"
-git2 = "0.13.25"
+git2 = "0.17.1"
 glob = "0.3.0"
 image = "0.24.3"
 imageproc = "0.23.0"
@@ -41,3 +41,7 @@ ansi_term = "0.12"
 
 [build-dependencies]
 winres = "0.1.12"
+
+[profile.release]
+lto = true
+codegen-units = 1

--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -420,7 +420,7 @@ fn install_binaries(config: &mut Config) {
 
 	let mut target_url: Option<String> = None;
 	for asset in res.assets {
-		#[cfg(target_os = "windows")]
+		#[cfg(any(target_os = "windows", target_os = "linux"))]
 		if asset.name.to_lowercase().contains("win") {
 			target_url = Some(asset.browser_download_url);
 			info!("Found binaries for platform Windows");

--- a/src/template.rs
+++ b/src/template.rs
@@ -37,7 +37,9 @@ fn create_template(
 		&project_location,
 	).expect("Unable to clone repository");
 
-	fs::remove_dir_all(project_location.join(".git")).unwrap();
+	if let Err(_) = fs::remove_dir_all(project_location.join(".git")) {
+		warn!("Unable to remove .git directory");
+	}
 
 	// Replace "Template" with project name (no spaces)
 	let filtered_name: String = name.chars().filter(|c| !c.is_whitespace()).collect();


### PR DESCRIPTION
Updates `git2`, allows windows binaries to be downloaded on linux, and doesn't force the .git directory to be deleted.