### PR TITLE
Fix: profile installation on macOS

### DIFF
--- a/src/info.rs
+++ b/src/info.rs
@@ -142,7 +142,7 @@ pub fn subcommand(config: &mut Config, cmd: Info) {
 						{
 							fail!("The path must point to the Geometry Dash app");
 							continue;
-						} else if path.join("Contents/MacOS/Geometry Dash").exists()
+						} else if !path.join("Contents/MacOS/Geometry Dash").exists()
 						{
 							fail!("The path must point to the Geometry Dash app, not a Steam shortcut");
 							continue;


### PR DESCRIPTION
Currently, geode only lets you install to the steam shortcut, not the actual application
Eg:
`/Users/luna/Applications/Geometry Dash.app` works (bad)
<img width="196" alt="image" src="https://github.com/geode-sdk/cli/assets/44179559/e81c671c-2072-4531-8603-137e9d13579b">
`/Users/luna/Library/Application Support/Steam/steamapps/common/Geometry Dash/Geometry Dash.app` doesn't (bad)
<img width="454" alt="image" src="https://github.com/geode-sdk/cli/assets/44179559/29596a33-f034-4fcf-858a-e8e64a9491ce">

This pr fixes that