### PR TITLE
Fix spritesheets not supporting single image

### DIFF
--- a/src/util/spritesheet.rs
+++ b/src/util/spritesheet.rs
@@ -113,7 +113,7 @@ fn initialize_spritesheet_bundle(
 
 	let mut max_width = (width_sum * mean_height).sqrt() as u32;
 
-	if max_width < largest_width {
+	if max_width < largest_width || sprites.len() == 1 {
 		max_width = largest_width + 2;
 	}
 


### PR DESCRIPTION
Issue lies is an oversight with how `max_width` is calculated. When having only a single image, it equals the `largest_size` and that leads to this particular if statement being skipped.

As a result, `TexturePacker` was trying to fit (for example) a 64x64 image, with `max_width` being 64. This, and the fact that default `TexturePackerConfig` has `texture_padding` set to 2 leads to an error message `TextureTooLargeToFitIntoAtlas`.

Tested different scenarios, including 127x128 and 128x127 images, with no issues detected.