### PR TITLE
Build mods for x64 to fix build errors on 2.206.

### DIFF
--- a/src/project_build.rs
+++ b/src/project_build.rs
@@ -46,7 +46,7 @@ pub fn build_project(
 				fail!("Sorry! but this cannot cross-compile to windows yet.");
 				fatal!("See the docs for more info: https://docs.geode-sdk.org/getting-started/cpp-stuff#linux");
 			}
-			conf_args.extend(["-A", "Win32"].map(String::from));
+			conf_args.extend(["-A", "x64"].map(String::from));
 		}
 		"mac" => {
 			if cross_compiling {


### PR DESCRIPTION
Currently attempting to build mods without this on the nightly branch (latest commit, for 2.206) will cause errors. (specifically "library machine type 'x64' conflicts with target machine type 'x86'")

I found this while trying to compile the Node IDs mod, to test the current stability of Geode on 2.206.

For anyone else attempting to compile mods for 2.206 before the full release of Geode 3.0, you can just run `cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -A x64` to configure, and `geode build -b` to build like normal.