### PR TITLE
use rustls native certs in `reqwest`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ texture_packer = "0.25.0"
 walkdir = "2"
 zip = "0.6.6"
 semver = "1.0.14"
-reqwest = { version = "0.12.2", features = ["json", "blocking"] }
+reqwest = { version = "0.12.2", default-features = false, features = ["json", "blocking", "stream", "rustls-tls-native-roots"] }
 cfg-if = "1.0.0"
 regex = "1.6.0"
 sha3 = "0.10.6"


### PR DESCRIPTION
this allows for standards such as TLS 1.3 to be supported consistently across all platforms, while still using the system's certificate store to recieve important security updates - regardless of what we do upstream