### PR TITLE
Fix dependencies not working for platform aliases

### DIFF
--- a/src/project.rs
+++ b/src/project.rs
@@ -310,27 +310,19 @@ pub fn check_dependencies(
 
 		// Fix platform aliases
 		if platforms.contains(&PlatformName::Android) {
-			if !platforms.contains(&PlatformName::Android64) {
-				platforms.insert(PlatformName::Android64);
-			}
-			if !platforms.contains(&PlatformName::Android32) {
-				platforms.insert(PlatformName::Android32);
-			}
+			platforms.insert(PlatformName::Android64);
+			platforms.insert(PlatformName::Android32);
 		}
 
 		if platforms.contains(&PlatformName::MacOS) {
-			if !platforms.contains(&PlatformName::MacArm) {
-				platforms.insert(PlatformName::MacArm);
-			}
-			if !platforms.contains(&PlatformName::MacIntel) {
-				platforms.insert(PlatformName::MacIntel);
-			}
-		} else if platform == PlatformName::MacOS {
-			if platforms.contains(&PlatformName::MacArm) ||
-				platforms.contains(&PlatformName::MacIntel)
-			{
-				platforms.insert(PlatformName::MacOS);
-			}
+			platforms.insert(PlatformName::MacArm);
+			platforms.insert(PlatformName::MacIntel);
+		}
+		if platform == PlatformName::MacOS
+			&& (platforms.contains(&PlatformName::MacArm)
+				|| platforms.contains(&PlatformName::MacIntel))
+		{
+			platforms.insert(PlatformName::MacOS);
 		}
 
 		// Skip dependencies not on this platform

--- a/src/project.rs
+++ b/src/project.rs
@@ -306,8 +306,35 @@ pub fn check_dependencies(
 
 	// check all dependencies
 	for dep in &mod_info.dependencies {
+		let mut platforms = dep.platforms.clone();
+
+		// Fix platform aliases
+		if platforms.contains(&PlatformName::Android) {
+			if !platforms.contains(&PlatformName::Android64) {
+				platforms.insert(PlatformName::Android64);
+			}
+			if !platforms.contains(&PlatformName::Android32) {
+				platforms.insert(PlatformName::Android32);
+			}
+		}
+
+		if platforms.contains(&PlatformName::MacOS) {
+			if !platforms.contains(&PlatformName::MacArm) {
+				platforms.insert(PlatformName::MacArm);
+			}
+			if !platforms.contains(&PlatformName::MacIntel) {
+				platforms.insert(PlatformName::MacIntel);
+			}
+		} else if platform == PlatformName::MacOS {
+			if platforms.contains(&PlatformName::MacArm) ||
+				platforms.contains(&PlatformName::MacIntel)
+			{
+				platforms.insert(PlatformName::MacOS);
+			}
+		}
+
 		// Skip dependencies not on this platform
-		if !dep.platforms.contains(&platform) {
+		if !platforms.contains(&platform) {
 			continue;
 		}
 

--- a/src/util/mod_file.rs
+++ b/src/util/mod_file.rs
@@ -222,6 +222,7 @@ pub enum PlatformName {
 	#[serde(rename = "win")]
 	#[value(alias = "win")]
 	Windows,
+	#[serde(rename = "mac")]
 	#[value(alias = "mac")]
 	MacOS,
 	#[serde(rename = "mac-intel")]


### PR DESCRIPTION
Yeah, they were still broken.

Let me know if there is some better approach to this I don't know of.