### PR TITLE
Fix local template repo path resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "edit-distance"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1046,7 @@ dependencies = [
  "crossterm_input",
  "dialoguer",
  "dirs",
+ "dunce",
  "edit-distance",
  "fontdue",
  "git2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ open = "5.1.4"
 rand = "0.9.2"
 tempfile = "3"
 dialoguer = "0.12.0"
+dunce = "1.0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
 terminal-clipboard = "0.4.1"

--- a/src/template.rs
+++ b/src/template.rs
@@ -216,7 +216,10 @@ pub fn build_template(location: Option<PathBuf>) {
 		info!("Please provide a local path to clone the repository from");
 		info!("It can be either a relative or a full path");
 		info!("Use this syntax: '/path/to/repo' or '/path/to/repo@branch'");
-		ask_value("Template", None, true)
+		dunce::canonicalize(ask_value("Template", None, true))
+			.nice_unwrap("Local repository does not exist")
+			.to_string_lossy()
+			.into_owned()
 	} else {
 		template_options[template_index].1.to_string()
 	};


### PR DESCRIPTION
On windows, trying to select a local template repository by giving it an absolute or relative path was giving errors on windows like
`| Fail | Unable to clone repository: unsupported URL protocol; class=Net (12)`

This change passes the path through a robust path resolver, which is compatible with RepoBuilder, and works for both relative and absolute paths.
 