### PR TITLE
Implement zstd compression and PNG optimization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,13 +35,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
- "cfg-if 1.0.3",
  "cipher",
- "cpufeatures",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -147,9 +147,6 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
-dependencies = [
- "derive_arbitrary",
-]
 
 [[package]]
 name = "arg_enum_proc_macro"
@@ -275,6 +272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+ "zeroize",
+]
+
+[[package]]
 name = "block2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,11 +371,11 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.2.2",
  "inout",
 ]
 
@@ -487,6 +494,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -521,10 +534,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.1"
+name = "const-oid"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -543,10 +562,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -649,19 +683,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "deflate64"
-version = "0.1.9"
+name = "crypto-common"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
 
 [[package]]
 name = "deranged"
-version = "0.5.3"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
-dependencies = [
- "powerfmt",
-]
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "derive-new"
@@ -672,17 +721,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "derive_arbitrary"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
 ]
 
 [[package]]
@@ -703,9 +741,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.6",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -933,7 +983,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
  "ttf-parser 0.21.1",
 ]
 
@@ -1058,6 +1108,7 @@ dependencies = [
  "image",
  "imageproc",
  "open",
+ "oxipng",
  "path-absolutize",
  "plist",
  "rand 0.9.2",
@@ -1119,8 +1170,21 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if 1.0.3",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.3+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if 1.0.3",
+ "js-sys",
+ "libc",
+ "r-efi 6.0.0",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1201,6 +1265,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,11 +1284,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1269,6 +1339,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1517,21 +1596,22 @@ checksum = "d0263a3d970d5c054ed9312c0057b4f3bde9c0b33836d3637361d4a9e6e7a408"
 
 [[package]]
 name = "indexmap"
-version = "2.11.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
+ "rayon",
 ]
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1676,6 +1756,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libdeflate-sys"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72753e0008ea87963d2f0770042d0df7abe51fafbb8dcaf618ac440f2f1fec0a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libdeflater"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ee41cf6fb1bb6030dfb59ffb7bc01ab26aade44142084c87f0fc7a1658fe71"
+dependencies = [
+ "libdeflate-sys",
+]
+
+[[package]]
 name = "libfuzzer-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,26 +1794,6 @@ dependencies = [
  "libssh2-sys",
  "libz-sys",
  "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "liblzma"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10bf66f4598dc77ff96677c8e763655494f00ff9c1cf79e2eb5bb07bc31f807d"
-dependencies = [
- "liblzma-sys",
-]
-
-[[package]]
-name = "liblzma-sys"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b9596486f6d60c3bbe644c0e1be1aa6ccc472ad630fe8927b456973d7cb736"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -1784,9 +1862,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "loop9"
@@ -1795,6 +1873,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2 0.11.0",
 ]
 
 [[package]]
@@ -2069,9 +2156,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -2355,6 +2442,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "oxipng"
+version = "10.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f80e5d92fd65b00e3953760e6a7616264a509b6bbee22502e0226774204da1a3"
+dependencies = [
+ "indexmap",
+ "libdeflater",
+ "log",
+ "rayon",
+ "rgb",
+ "rustc-hash",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,11 +2487,11 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest",
+ "digest 0.11.3",
  "hmac",
 ]
 
@@ -2471,9 +2572,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppmd-rust"
-version = "1.2.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c834641d8ad1b348c9ee86dec3b9840d805acd5f24daa5f90c788951a52ff59b"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -2559,6 +2660,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radix_trie"
@@ -2799,9 +2906,12 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.52"
+version = "0.8.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -2828,6 +2938,12 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -2967,22 +3083,32 @@ checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.106",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3021,13 +3147,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if 1.0.3",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3037,8 +3163,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if 1.0.3",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if 1.0.3",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3050,7 +3187,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "hex",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
 ]
 
@@ -3156,6 +3293,17 @@ name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3319,29 +3467,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.42"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca967379f9d8eb8058d86ed467d81d03e81acd45757e4ca341c24affbe8e8e3"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9108bb380861b07264b950ded55a44a14a4adc68b9f5efd85aafc3aa4d40a68"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.23"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7182799245a7264ce590b349d90338f1c1affad93d2639aed5f8f69c090b334c"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3545,10 +3694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
-name = "typenum"
-version = "1.18.0"
+name = "typed-path"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -4275,20 +4430,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.106",
-]
 
 [[package]]
 name = "zerotrie"
@@ -4325,26 +4466,26 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.6.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c034aa6c54f654df20e7dc3713bc51705c12f280748fb6d7f40f87c696623e34"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes",
- "arbitrary",
  "bzip2",
  "constant_time_eq",
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.3.3",
+ "getrandom 0.4.3",
  "hmac",
  "indexmap",
- "liblzma",
+ "lzma-rust2",
  "memchr",
  "pbkdf2",
  "ppmd-rust",
  "sha1",
  "time",
+ "typed-path",
  "zeroize",
  "zopfli",
  "zstd",
@@ -4358,9 +4499,9 @@ checksum = "626bd9fa9734751fc50d6060752170984d7053f5a39061f524cda68023d4db8a"
 
 [[package]]
 name = "zopfli"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edfc5ee405f504cd4984ecc6f14d02d55cfda60fa4b689434ef4102aae150cd7"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
 dependencies = [
  "bumpalo",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "matcool",
     "ConfiG <cgytrus@cgyt.ru>",
 ]
-edition = "2021"
+edition = "2024"
 build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -32,7 +32,7 @@ serde_json = { version = "1.0.117", features = ["preserve_order"] }
 sha256 = "1.5.0"
 texture_packer = "0.30.0"
 walkdir = "2.5.0"
-zip = "4.6.0"
+zip = "8.6.0"
 semver = "1.0.23"
 reqwest = { version = "0.12.5", features = ["json", "blocking"] }
 regex = "1.10.5"
@@ -40,6 +40,7 @@ edit-distance = "2.1.0"
 vec1 = { version = "1.12.1", features = ["serde"] }
 crossterm_input = "0.5.0"
 open = "5.1.4"
+oxipng = { version = "10", default-features = false, features = ["parallel"] }
 rand = "0.9.2"
 tempfile = "3"
 dialoguer = "0.12.0"

--- a/src/package.rs
+++ b/src/package.rs
@@ -567,7 +567,11 @@ fn merge_packages(inputs: Vec<PathBuf>, zstd: bool, optimize_pngs: bool) {
 		}
 	}
 
+	// close archive so it can be safely overwritten
+	drop(first_archive);
+
 	out_archive.finish().nice_unwrap("Unable to write to zip");
+
 	out_file
 		.persist(inputs[0].clone())
 		.nice_unwrap("Unable to persist zip");

--- a/src/package.rs
+++ b/src/package.rs
@@ -3,17 +3,28 @@ use std::io::{Read, Seek, Write};
 use std::path::{Path, PathBuf};
 
 use clap::Subcommand;
+use semver::Version;
+use tempfile::NamedTempFile;
 use zip::write::FileOptions;
-use zip::ZipWriter;
+use zip::{CompressionMethod, ZipWriter};
 
 use crate::config::Config;
+use crate::file::copy_dir_recursive;
 use crate::util::bmfont;
 use crate::util::cache::CacheBundle;
-use crate::util::mod_file::{parse_mod_info, ModFileInfo};
+use crate::util::mod_file::{ModFileInfo, parse_mod_info};
 use crate::util::spritesheet;
+use crate::{NiceUnwrap, done, fatal, info, warn};
 use crate::{cache, project};
-use crate::{done, fatal, info, warn, NiceUnwrap};
-use crate::file::copy_dir_recursive;
+
+// Level for new packages, which is typically either local builds or intermediate CI builds with 1 platform,
+// here it's best for it to be a low level for speed, as the package will be merged later anyway
+const ZSTD_LEVEL_NEW: i64 = 3;
+// Level for merged packages, most often used for release CI builds, here we can afford to spend a few extra seconds to compress.
+// Level 18 was chosen as a sweet spot that provides very good compression for most mods while not being unreasonably slow like 19+
+const ZSTD_LEVEL_MERGED: i64 = 18;
+// Zstd support was added to the loader in v5.9.0
+const ZSTD_MIN_GEODE_VERSION: Version = Version::new(5, 9, 0);
 
 #[derive(Subcommand, Debug)]
 #[clap(rename_all = "kebab-case")]
@@ -43,12 +54,24 @@ pub enum Package {
 		/// Whether to install the generated package after creation
 		#[clap(short, long)]
 		install: bool,
+
+		/// Use zstd level 3 compression instead of deflate, improving file size and decompression speeds.
+		#[clap(long)]
+		zstd: bool,
 	},
 
 	/// Merge multiple packages
 	Merge {
 		/// Packages to merge
 		packages: Vec<PathBuf>,
+
+		/// Use zstd level 18 compression instead of deflate, significantly reducing size at the cost of taking a few extra seconds.
+		#[clap(long)]
+		zstd: bool,
+
+		/// Apply slow but lossless recompression to all PNG files, reducing size of resources.
+		#[clap(long)]
+		optimize_pngs: bool,
 	},
 
 	/// Check the dependencies of a project.
@@ -101,34 +124,38 @@ pub fn install(config: &Config, pkg_path: &Path) {
 	);
 }
 
-fn zip_folder(path: &Path, output: &Path) {
+fn zip_folder(path: &Path, output: &Path, zstd_level: Option<i64>) {
 	info!("Zipping");
 
 	// Setup zip
 	let mut zip_file = ZipWriter::new(fs::File::create(output).unwrap());
-	let zip_options =
-		FileOptions::<()>::default().compression_method(zip::CompressionMethod::Deflated);
 
 	// Iterate files in target path
 	for item in walkdir::WalkDir::new(path) {
 		let item = item.unwrap();
+		let metadata = item.metadata().unwrap();
 
 		// Only look at files
-		if item.metadata().unwrap().is_file() {
-			// Relativize
-			let mut relative_path = item
-				.path()
-				.strip_prefix(path)
-				.unwrap()
-				.to_str()
-				.unwrap()
-				.to_string();
-
-			relative_path = relative_path.replace('\\', "/");
-
-			zip_file.start_file(relative_path, zip_options).unwrap();
-			zip_file.write_all(&fs::read(item.path()).unwrap()).unwrap();
+		if !metadata.is_file() {
+			continue;
 		}
+
+		let file_name = item.file_name().to_str().unwrap();
+		let options = zip_file_options(file_name, zstd_level);
+
+		// Relativize
+		let mut relative_path = item
+			.path()
+			.strip_prefix(path)
+			.unwrap()
+			.to_str()
+			.unwrap()
+			.to_string();
+
+		relative_path = relative_path.replace('\\', "/");
+
+		zip_file.start_file(relative_path, options).unwrap();
+		zip_file.write_all(&fs::read(item.path()).unwrap()).unwrap();
 	}
 
 	zip_file.finish().nice_unwrap("Unable to zip");
@@ -256,9 +283,15 @@ fn create_package(
 	binaries: Vec<PathBuf>,
 	raw_output: Option<PathBuf>,
 	do_install: bool,
+	use_zstd: bool,
 ) {
 	// Parse mod.json
 	let mod_file_info = parse_mod_info(root_path);
+
+	// if `use_zstd` is true but the mod targets an outdated loader version, throw an error
+	if use_zstd {
+		assert_zstd_support(&mod_file_info.geode);
+	}
 
 	// path to the final .geode file
 	let mut output = raw_output.unwrap_or(root_path.join(format!("{}.geode", mod_file_info.id)));
@@ -390,7 +423,7 @@ fn create_package(
 
 	new_cache.save(working_dir);
 
-	zip_folder(working_dir, &output);
+	zip_folder(working_dir, &output, use_zstd.then_some(ZSTD_LEVEL_NEW));
 
 	if do_install {
 		let config = Config::new().assert_is_setup();
@@ -410,14 +443,26 @@ pub fn mod_json_from_archive<R: Seek + Read>(input: &mut zip::ZipArchive<R>) -> 
 	serde_json::from_str::<serde_json::Value>(&text).nice_unwrap("Unable to parse mod.json")
 }
 
-fn merge_packages(inputs: Vec<PathBuf>) {
+fn merge_packages(inputs: Vec<PathBuf>, zstd: bool, optimize_pngs: bool) {
 	let mut archives: Vec<_> = inputs
 		.iter()
 		.map(|x| {
-			zip::ZipArchive::new(fs::File::options().read(true).write(true).open(x).unwrap())
+			zip::ZipArchive::new(fs::File::options().read(true).open(x).unwrap())
 				.nice_unwrap("Unable to unzip")
 		})
 		.collect();
+
+	// Zstd requires Geode v5.9.0+
+	if zstd {
+		let mod_json = mod_json_from_archive(&mut archives[0]);
+		let geode_version = mod_json
+			.get("geode")
+			.and_then(|x| x.as_str())
+			.and_then(|x| x.replace('v', "").parse::<Version>().ok())
+			.nice_unwrap("Did not find geode version in mod.json");
+
+		assert_zstd_support(&geode_version);
+	}
 
 	// Sanity check
 	let mut mod_ids: Vec<_> = archives
@@ -445,9 +490,46 @@ fn merge_packages(inputs: Vec<PathBuf>) {
 		}
 	});
 
-	let mut out_archive = ZipWriter::new_append(archives.remove(0).into_inner())
-		.nice_unwrap("Unable to create zip writer");
+	// copy all files from first archive, re-compress resources
+	let mut first_archive = archives.remove(0);
+	let file_names: Vec<_> = first_archive.file_names().map(|x| x.to_string()).collect();
 
+	// store the temporary file in the same folder as the other .geode files, to avoid cross-device links
+	let out_temp_dir = inputs[0].parent().unwrap();
+	let mut out_file =
+		NamedTempFile::new_in(out_temp_dir).nice_unwrap("Failed to create temp file");
+	let mut out_archive = ZipWriter::new(&mut out_file);
+
+	for name in file_names {
+		let mut entry = first_archive.by_name(&name).unwrap();
+
+		// if zstd and png optimization are disabled, we can copy 1:1 which is faster
+		if !zstd && !optimize_pngs {
+			out_archive
+				.raw_copy_file(entry)
+				.nice_unwrap("Unable to copy file between zips");
+			continue;
+		}
+
+		let mut data = Vec::new();
+		entry
+			.read_to_end(&mut data)
+			.nice_unwrap("Unable to read file from zip");
+
+		if name.ends_with(".png") && optimize_pngs {
+			data = oxipng::optimize_from_memory(&data, &oxipng::Options::from_preset(4))
+				.nice_unwrap("Failed to optimize .png");
+		}
+
+		write_file_to_zip(
+			&mut out_archive,
+			&name,
+			&data,
+			zstd.then_some(ZSTD_LEVEL_MERGED),
+		);
+	}
+
+	// for the remainder of archives, copy just the binaries
 	for archive in &mut archives {
 		let potential_names = [".dylib", ".so", ".dll", ".lib", ".pdb"];
 
@@ -462,14 +544,33 @@ fn merge_packages(inputs: Vec<PathBuf>) {
 			if potential_names.iter().any(|x| file.ends_with(*x)) {
 				println!("{}", file);
 
-				out_archive
-					.raw_copy_file(archive.by_name(&file).nice_unwrap("Unable to fetch file"))
-					.nice_unwrap("Unable to transfer binary");
+				if !zstd {
+					out_archive
+						.raw_copy_file(archive.by_name(&file).nice_unwrap("Unable to fetch file"))
+						.nice_unwrap("Unable to transfer binary");
+				} else {
+					let mut data = Vec::new();
+					archive
+						.by_name(&file)
+						.nice_unwrap("Unable to fetch file")
+						.read_to_end(&mut data)
+						.nice_unwrap("Unable to read file from zip");
+
+					write_file_to_zip(
+						&mut out_archive,
+						&file,
+						&data,
+						zstd.then_some(ZSTD_LEVEL_MERGED),
+					);
+				}
 			}
 		}
 	}
 
 	out_archive.finish().nice_unwrap("Unable to write to zip");
+	out_file
+		.persist(inputs[0].clone())
+		.nice_unwrap("Unable to persist zip");
 	done!(
 		"Successfully merged binaries into {}",
 		inputs[0].to_str().unwrap()
@@ -488,13 +589,18 @@ pub fn subcommand(cmd: Package) {
 			binary: binaries,
 			output,
 			install,
-		} => create_package(&root_path, binaries, output, install),
+			zstd,
+		} => create_package(&root_path, binaries, output, install, zstd),
 
-		Package::Merge { packages } => {
+		Package::Merge {
+			packages,
+			zstd,
+			optimize_pngs,
+		} => {
 			if packages.len() < 2 {
 				fatal!("Merging requires at least two packages");
 			}
-			merge_packages(packages)
+			merge_packages(packages, zstd, optimize_pngs)
 		}
 
 		#[allow(deprecated)]
@@ -510,4 +616,45 @@ pub fn subcommand(cmd: Package) {
 			shut_up,
 		} => create_package_resources_only(&root_path, &output, shut_up),
 	}
+}
+
+fn assert_zstd_support(target_geode_version: &Version) {
+	if target_geode_version < &ZSTD_MIN_GEODE_VERSION {
+		fatal!(
+			"Zstd compression is not supported by the target loader version {}. Please update the loader version in mod.json to {} or newer or disable Zstd compression.",
+			target_geode_version,
+			ZSTD_MIN_GEODE_VERSION
+		);
+	}
+}
+
+fn zip_file_options(name: &'_ str, zstd_level: Option<i64>) -> FileOptions<'_, ()> {
+	if let Some(mut level) = zstd_level
+		&& name != "mod.json"
+	{
+		// for .png files just use level 3, they are already hardly compressible
+		if name.ends_with(".png") {
+			level = 3;
+		}
+
+		FileOptions::default()
+			.compression_method(CompressionMethod::Zstd)
+			.compression_level(Some(level))
+	} else {
+		// store mod.json as deflate, so that older Geode versions can still parse it instead of throwing an invalid metadata error
+		FileOptions::default().compression_method(CompressionMethod::Deflated)
+	}
+}
+
+fn write_file_to_zip<W: Write + Seek>(
+	zip: &mut ZipWriter<W>,
+	name: &str,
+	data: &[u8],
+	zstd_level: Option<i64>,
+) {
+	let opts = zip_file_options(name, zstd_level);
+	zip.start_file(name, opts)
+		.nice_unwrap("Unable to start file in zip");
+	zip.write_all(data)
+		.nice_unwrap("Unable to write file to zip");
 }


### PR DESCRIPTION
Loader v5.9.0 added support for unzipping Zstd entries in archives, so the new flags are gated behind target Geode version being v5.9.0 or higher. `mod.json` is always deflated, so older Geode versions can read metadata in a `.geode` file with no problems.

The new `--zstd` flag applies to `geode package new` (local builds, intermediary single-platform CI builds) to apply level 3 Zstd compression and to `geode package merge` to apply level 18 compression. Level 3 is the default level and is good for development/intermediary artifacts, while level 18 takes a lot more time and is good for release builds.

For example, stats for the Globed DLL:
* 17.5 MiB uncompressed
* 5.6 MiB with default Deflate
* **5.1** MiB with Zstd level 3
* **4.1** MiB with Zstd level 18

Zstd absolutely stomps the competition by being smaller and faster to compress on low levels. High levels shine with reduced sizes and still blazing fast decompression speeds (level 18 will still be unzipped much faster than regular deflate, so faster mod load times)

On top of that, `oxipng` is now used to more efficiently compress `.png` files in the final merged mod, if the `--optimize-pngs` flag is passed. This yields pretty significant size improvements yet again, at the cost of taking some extra time (for example Globed resources go from 9.1 MiB to **7.2 MiB**). The compression is lossless and has no negative impact on texture load time.
