### PR TITLE
fix: respect user proxy settings when executing git clone and fetch commands

### DIFF
--- a/src/sdk.rs
+++ b/src/sdk.rs
@@ -3,7 +3,7 @@ use crate::util::logging::ask_confirm;
 use clap::Subcommand;
 use colored::Colorize;
 use git2::build::{CheckoutBuilder, RepoBuilder};
-use git2::{FetchOptions, RemoteCallbacks, Repository, StatusOptions};
+use git2::{FetchOptions, ProxyOptions, RemoteCallbacks, Repository, StatusOptions};
 use path_absolutize::Absolutize;
 use regex::Regex;
 use reqwest::header::{AUTHORIZATION, USER_AGENT};
@@ -348,8 +348,13 @@ fn clone_repo(url: &str, into: &Path) -> Result<Repository, git2::Error> {
 		true
 	});
 
+	// Let git2 derive user proxy settings
+	let mut proxy = ProxyOptions::new();
+	proxy.auto();
+
 	let mut fetch = FetchOptions::new();
 	fetch.remote_callbacks(callbacks);
+	fetch.proxy_options(proxy);
 
 	let mut builder = RepoBuilder::new();
 	builder.fetch_options(fetch);
@@ -422,9 +427,17 @@ fn fetch_repo_info(repo: &git2::Repository) -> git2::MergeAnalysis {
 		true
 	});
 
+	// Let git2 derive user proxy settings
+	let mut proxy = ProxyOptions::new();
+	proxy.auto();
+
+	let mut fetch = FetchOptions::new();
+	fetch.remote_callbacks(callbacks);
+	fetch.proxy_options(proxy);
+
 	let res = remote.fetch(
 		&["main"],
-		Some(FetchOptions::new().remote_callbacks(callbacks)),
+		Some(&mut fetch),
 		None,
 	);
 	if res.as_ref().is_err_and(|e| {

--- a/src/template.rs
+++ b/src/template.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::sdk::get_version;
 use crate::util::logging::{ask_confirm, ask_value};
 use crate::{done, info, warn, NiceUnwrap};
+use git2::{FetchOptions, ProxyOptions};
 use git2::build::RepoBuilder;
 use path_absolutize::Absolutize;
 use regex::Regex;
@@ -47,8 +48,18 @@ fn create_template(template: CreateTemplate) {
 	// Remove this if you dont think its needed
 	info!("Cloning branch {} of repository {}", branch, used_template);
 
+	// Let git2 derive user proxy settings
+	let mut proxy = ProxyOptions::new();
+	proxy.auto();
+
+	let mut fetch = FetchOptions::new();
+	fetch.proxy_options(proxy);
+
+	let mut builder = RepoBuilder::new();
+	builder.fetch_options(fetch);
+
 	// Clone repository
-	RepoBuilder::new()
+	builder
 		.branch(branch)
 		.clone(used_template, &template.project_location)
 		.nice_unwrap("Unable to clone repository");


### PR DESCRIPTION
Currently Geode CLI does not follow http and https proxy git settings. This PR fixes this issue by invoking

```rust
let mut proxy = ProxyOptions::new();
proxy.auto();
```

and using `proxy` in `FetchOptions` before exeucting git2 fetch or clone commands, facilitating automatic detection of git proxy settings. Built and tested on Arch Linux, x86_64, but it should take effect in all OSes.